### PR TITLE
feat: convert layout table to single column table

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,29 +17,29 @@
   <body id="body" style="margin:0; padding:0; height: 100%;">
     <table role="presentation" style="border: 1px solid black; height: 100%; width: 100%; background-color: #f2f2f2;">
       <tr>
-        <td align="center" style="padding:20px;">
+        <td style="padding:20px;  ">
           <table role="presentation" style="width:600px; background:#ffffff;">
             
             <tr>
-              <td align="center" style="padding:20px;">
+              <td style="padding:20px; text-align: center;">
                 <img src="./images/trump-vance.jpg" alt="Logo" style="width:250px; height:auto;" />
               </td>
             </tr>
 
             <tr>
-              <td align="center" style="padding:0 20px 20px;">
+              <td style="padding:0 20px 20px; text-align: center;">
                 <h1 style="margin:0;">🚨 PATRIOT ALERT:<br>FREEDOMS UNDER ATTACK 🚨</h1>
               </td>
             </tr>
 
             <tr>
-              <td align="center" style="padding:0 20px 20px;">
+              <td style="padding:0 20px 20px; text-align: center;">
                 <img src="./images/flag.jpg" alt="" style="width:100%; max-width:560px; height:auto;" />
               </td>
             </tr>
 
             <tr>
-              <td style="padding:20px; background:url('./images/bg-texture.jpg') center/cover no-repeat; color:#000; text-align:left;">
+              <td style="padding:20px; background:url('./images/bg-texture.jpg') center/cover no-repeat; color:#000; text-align:center;">
                 <p style="margin:0 0 14px 0;">
                   Patriot, this is not a drill. Right now, powerful forces are working to take away your freedoms, your traditions, and even your morning coffee. 
                 </p>
@@ -56,13 +56,13 @@
             </tr>
 
             <tr>
-              <td align="center" style="padding:20px;">
+              <td style="padding:20px; text-align: center;">
                 <a href="#" style="text-decoration:underline;">Donate $17.76 Now</a>
               </td>
             </tr>
 
             <tr>
-              <td align="center" style="padding:20px; font-size:12px; color:#555;">
+              <td style="padding:20px; font-size:12px; color:#555; text-align: center;">
                 <p style="margin:0;">
                   Paid for by Defenders of Freedom Forever. If you’d rather not receive updates, feel free to 
                   <a href="#" style="color:#777777; text-decoration:underline;">unsubscribe</a>.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 100%;">
   <head>
     <title></title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -14,47 +14,65 @@
       a[x-apple-data-detectors], u + #body a, #MessageViewBody a { color: inherit !important; text-decoration: none !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important; }
     </style>
   </head>
-  <body id="body" style="margin:0; padding:0">
-	
-    <div style="max-width:600px; margin:0 auto; text-align:center; padding:20px;">
-      
-       <!-- Logo image -->
-      <img src="./images/trump-vance.jpg" alt="Logo" style="width:250px; height:auto; display:block; margin:0 auto 20px;" />
-      
-      <!-- Headline -->
-      <h1 style="margin:0 0 20px 0;">🚨 PATRIOT ALERT:<br> FREEDOMS UNDER ATTACK 🚨</h1>
-      
-      <!-- Hero Image -->
-      <img src="./images/flag.jpg" alt="" style="width:100%; max-width:560px; height:auto; display:block; margin:0 auto 20px;" />
-      
-      <!-- Body copy -->
-      <div style="text-align:left; margin:0 auto 20px; max-width:560px;">
-        <p style="margin:0 0 14px 0;">
-          Patriot, this is not a drill. Right now, powerful forces are working to take away your freedoms, your traditions, and even your morning coffee. 
-        </p>
-        <p style="margin:0 0 14px 0;">
-          We’ve activated the Official Freedom Defense Fund™, and we need you to step up. Without your help, everything we hold dear could disappear. 
-        </p>
-        <p style="margin:0 0 14px 0;">
-          <strong>Your support is so critical that we’re offering an opportunity to increase your impact by 1776% if you act within the NEXT HOUR.</strong>
-        </p>
-        <p style="margin:0;">
-          Stand tall. Defend freedom. Make history. 
-        </p>
-      </div>
-      
-      <!-- Button -->
-      <div style="margin:0 0 24px 0;">
-        <a href="#" style="text-decoration:underline;">Donate $17.76 Now</a>
-      </div>
-      
-      <!-- Footer -->
-      <div style="max-width:560px; margin:0 auto; font-size:12px; color:#555; line-height:1.4; text-align:center;">
-        <p style="margin:0 0 8px 0;">
-          Paid for by Defenders of Freedom Forever. If you’d rather not receive updates, feel free to 
-          <a href="#" style="color:#777777; text-decoration:underline;">unsubscribe</a>.
-        </p>
-      </div>
-    </div>
+  <body id="body" style="margin:0; padding:0; height: 100%;">
+    <table role="presentation" style="border: 1px solid black; height: 100%; width: 100%; background-color: #f2f2f2;">
+      <tr>
+        <td align="center" style="padding:20px;">
+          <table role="presentation" style="width:600px; background:#ffffff;">
+            
+            <tr>
+              <td align="center" style="padding:20px;">
+                <img src="./images/trump-vance.jpg" alt="Logo" style="width:250px; height:auto;" />
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:0 20px 20px;">
+                <h1 style="margin:0;">🚨 PATRIOT ALERT:<br>FREEDOMS UNDER ATTACK 🚨</h1>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:0 20px 20px;">
+                <img src="./images/flag.jpg" alt="" style="width:100%; max-width:560px; height:auto;" />
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px; background:url('./images/bg-texture.jpg') center/cover no-repeat; color:#000; text-align:left;">
+                <p style="margin:0 0 14px 0;">
+                  Patriot, this is not a drill. Right now, powerful forces are working to take away your freedoms, your traditions, and even your morning coffee. 
+                </p>
+                <p style="margin:0 0 14px 0;">
+                  We’ve activated the Official Freedom Defense Fund™, and we need you to step up. Without your help, everything we hold dear could disappear. 
+                </p>
+                <p style="margin:0 0 14px 0;">
+                  <strong>Your support is so critical that we’re offering an opportunity to increase your impact by 1776% if you act within the NEXT HOUR.</strong>
+                </p>
+                <p style="margin:0;">
+                  Stand tall. Defend freedom. Make history. 
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:20px;">
+                <a href="#" style="text-decoration:underline;">Donate $17.76 Now</a>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:20px; font-size:12px; color:#555;">
+                <p style="margin:0;">
+                  Paid for by Defenders of Freedom Forever. If you’d rather not receive updates, feel free to 
+                  <a href="#" style="color:#777777; text-decoration:underline;">unsubscribe</a>.
+                </p>
+              </td>
+            </tr>
+
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>


### PR DESCRIPTION
Wrapped content in a single-column table, set width to 600px (recommended standard), and added a grey background for styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Rebuilt the email into a full-height, table-based layout (outer full-page table with centered 600px inner table) while preserving all content and CTA text.

* **Style**
  * Added inline full-page height, background texture, and centered texture for the body area.
  * Applied inline styles, adjusted padding/margins, and updated heading/image/CTA presentation for consistent email rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->